### PR TITLE
solve: getting nan in pseudotimes_interp

### DIFF
--- a/pyslingshot/slingshot.py
+++ b/pyslingshot/slingshot.py
@@ -192,6 +192,7 @@ class Slingshot:
                                  for l in range(len(self.lineages))]
             self.cell_weights = np.stack(self.cell_weights, axis=1)
 
+
         for epoch in tqdm(range(num_epochs)):
             # Calculate cell weights
             # cell weight is a matrix #cells x #lineages indicating cell-lineage assignment
@@ -298,7 +299,7 @@ class Slingshot:
                     self.data,
                     max_iter=1,
                     w=self.cell_weights[:, l_idx],
-                    s=this_s,
+                    param_s=this_s,
                 )
 
                 if sum(np.isnan(curve.pseudotimes_interp)) == 0:


### PR DESCRIPTION
when UnivariateSpline fit failed due to small s value, pseudotimes_interp get nan value. and pyslingshot fails.

This patch dependent on another pull request for 'pcurvepy' (https://github.com/mossjacob/pcurvepy/pull/3)

One issue raised in #9  is solved here.
```
[np.isnan(slingshot.curves[i].pseudotimes_interp).any() for i in range(len(slingshot.curves))]
# [True, False, False, False, False, False, False, False]
```
Test: set this_s value to 1 in slingshot.py and run slingshot fit